### PR TITLE
Hide switches / actions seperately.  BREAKING - `controls` no longer supported as hide option.  ⛔ 🚒 🪨 

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,7 +445,7 @@ collapsed_sections:
 - [x] **`Additional visualization options`**: using HA native more-info, etc. - thanks @dunxd
 - [x] **`Pause ad-blocking`**: temporarily disable filtering for specified durations - thanks @StuartHaire
 - [x] **`Entity ordering`**: customize the order of displayed entities - thanks @Teleportist
-- [x] **`Section hiding`**: ability to disable sections or entities - thanks @pcnate
+- [x] **`Section hiding`**: ability to disable sections or entities - thanks @pcnate, @bastgau
 - [x] **`Visual separators`**: add dividers for switches - thanks @Teleportist
 - [ ] **`Links directly to sub pages`**: direct links to specific Pi-hole admin pages
 

--- a/README.md
+++ b/README.md
@@ -253,12 +253,13 @@ Actions can be configured to perform various operations such as:
 
 The following section names can be used with `exclude_sections`:
 
+- actions
+- footer
 - header
+- pause
 - statistics
 - sensors
-- controls
-- pause
-- footer
+- switches
 
 ### Collapse Options
 
@@ -327,7 +328,7 @@ type: custom:pi-hole
 device_id: pi_hole_device_1
 exclude_sections:
   - sensors
-  - controls
+  - switches
 exclude_entities:
   - button.pi_hole_action_refresh_data
   - sensor.pi_hole_latest_data_refresh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hole",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hole",
-      "version": "0.11.1",
+      "version": "0.11.2",
       "license": "ISC",
       "dependencies": {
         "@lit/task": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-hole",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-hole",
-      "version": "0.11.0",
+      "version": "0.11.1",
       "license": "ISC",
       "dependencies": {
         "@lit/task": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hole",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "author": "Patrick Masters",
   "license": "ISC",
   "description": "UDPATE ME.",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-hole",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "author": "Patrick Masters",
   "license": "ISC",
   "description": "UDPATE ME.",

--- a/src/cards/editor.ts
+++ b/src/cards/editor.ts
@@ -68,8 +68,20 @@ const SCHEMA: HaFormSchema[] = [
             mode: 'list' as const,
             options: [
               {
+                label: 'Actions',
+                value: 'actions',
+              },
+              {
+                label: 'Footer',
+                value: 'footer',
+              },
+              {
                 label: 'Header',
                 value: 'header',
+              },
+              {
+                label: 'Pause Buttons',
+                value: 'pause',
               },
               {
                 label: 'Statistics',
@@ -80,16 +92,8 @@ const SCHEMA: HaFormSchema[] = [
                 value: 'sensors',
               },
               {
-                label: 'Controls',
-                value: 'controls',
-              },
-              {
-                label: 'Pause Buttons',
-                value: 'pause',
-              },
-              {
-                label: 'Footer',
-                value: 'footer',
+                label: 'Switches',
+                value: 'switches',
               },
             ],
           },

--- a/src/html/pi-flavors.ts
+++ b/src/html/pi-flavors.ts
@@ -27,8 +27,6 @@ const controls = (
   device: PiHoleDevice,
   config: Config,
 ): TemplateResult | typeof nothing => {
-  if (!show(config, 'controls')) return nothing;
-
   const sectionConfig: SectionConfig = config.controls ?? {
     tap_action: {
       action: 'toggle',
@@ -44,7 +42,8 @@ const controls = (
   const switchCollapsed = isCollapsed(config, 'switches');
   const actionsCollapsed = isCollapsed(config, 'actions');
 
-  return html`<div class="collapsible-section">
+  return html`${show(config, 'switches')
+    ? html`<div class="collapsible-section">
         <div
           class="section-header"
           @click=${(e: Event) => toggleSection(e, '.switches')}
@@ -74,9 +73,10 @@ const controls = (
             return stateContent(hass, piSwitch);
           })}
         </div>
-      </div>
-
-      <div class="collapsible-section">
+      </div>`
+    : nothing}
+  ${show(config, 'actions')
+    ? html`<div class="collapsible-section">
         <div
           class="section-header"
           @click=${(e: Event) => toggleSection(e, '.actions')}
@@ -93,7 +93,8 @@ const controls = (
           })}
         </div>
       </div>
-    </div>`;
+    </div>`
+    : nothing}`;
 };
 
 /**

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -43,12 +43,13 @@ export interface Config {
 
 export type CollapsibleSections = 'actions' | 'pause' | 'switches';
 export type Sections =
+  | 'actions'
+  | 'footer'
   | 'header'
+  | 'pause'
   | 'statistics'
   | 'sensors'
-  | 'pause'
-  | 'controls'
-  | 'footer';
+  | 'switches';
 
 export interface SectionConfig {
   /** Action to perform on tap */

--- a/test/cards/editor.spec.ts
+++ b/test/cards/editor.spec.ts
@@ -141,8 +141,20 @@ export default () => {
                     mode: 'list' as const,
                     options: [
                       {
+                        label: 'Actions',
+                        value: 'actions',
+                      },
+                      {
+                        label: 'Footer',
+                        value: 'footer',
+                      },
+                      {
                         label: 'Header',
                         value: 'header',
+                      },
+                      {
+                        label: 'Pause Buttons',
+                        value: 'pause',
                       },
                       {
                         label: 'Statistics',
@@ -153,16 +165,8 @@ export default () => {
                         value: 'sensors',
                       },
                       {
-                        label: 'Controls',
-                        value: 'controls',
-                      },
-                      {
-                        label: 'Pause Buttons',
-                        value: 'pause',
-                      },
-                      {
-                        label: 'Footer',
-                        value: 'footer',
+                        label: 'Switches',
+                        value: 'switches',
                       },
                     ],
                   },

--- a/test/common/show-section.spec.ts
+++ b/test/common/show-section.spec.ts
@@ -16,7 +16,8 @@ export default () => {
         expect(show(config, 'header')).to.be.true;
         expect(show(config, 'statistics')).to.be.true;
         expect(show(config, 'sensors')).to.be.true;
-        expect(show(config, 'controls')).to.be.true;
+        expect(show(config, 'actions')).to.be.true;
+        expect(show(config, 'switches')).to.be.true;
         expect(show(config, 'footer')).to.be.true;
       });
 
@@ -29,7 +30,7 @@ export default () => {
 
         // Act & Assert
         expect(show(config, 'header')).to.be.true;
-        expect(show(config, 'controls')).to.be.true;
+        expect(show(config, 'actions')).to.be.true;
         expect(show(config, 'footer')).to.be.true;
       });
 
@@ -59,7 +60,8 @@ export default () => {
         expect(show(config, 'header')).to.be.true;
         expect(show(config, 'statistics')).to.be.true;
         expect(show(config, 'sensors')).to.be.true;
-        expect(show(config, 'controls')).to.be.true;
+        expect(show(config, 'actions')).to.be.true;
+        expect(show(config, 'switches')).to.be.true;
         expect(show(config, 'footer')).to.be.true;
       });
     });

--- a/test/html/pi-flavors.spec.ts
+++ b/test/html/pi-flavors.spec.ts
@@ -8,7 +8,7 @@ import { fixture } from '@open-wc/testing-helpers';
 import type { Config } from '@type/config';
 import type { EntityInformation, PiHoleDevice } from '@type/types';
 import { expect } from 'chai';
-import { html, nothing, type TemplateResult } from 'lit';
+import { html, type TemplateResult } from 'lit';
 import { stub } from 'sinon';
 
 export default () => {
@@ -97,26 +97,6 @@ export default () => {
       stateContentStub.restore();
       showSectionStub.restore();
       isCollapsedStub.restore();
-    });
-
-    it('should return nothing when show returns false for controls section', async () => {
-      // Configure show to return false for controls section
-      showSectionStub.withArgs(mockConfig, 'controls').returns(false);
-
-      // Call createCardActions
-      const result = createCardActions(
-        mockElement,
-        mockHass,
-        mockDevice,
-        mockConfig,
-      );
-
-      // Assert that nothing is returned
-      expect(result).to.equal(nothing);
-
-      // Verify that helper functions were not called
-      expect(createActionButtonStub.called).to.be.false;
-      expect(stateContentStub.called).to.be.false;
     });
 
     it('should render separate divs for switches and actions', async () => {


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR changes or adds -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

<!-- Describe the tests you ran and how others can test your changes -->

- [ ] Tested on Home Assistant version: <!-- Add version number -->
- [ ] Tested on browser(s): <!-- List browsers -->

## Screenshots

<!-- If applicable, add screenshots to help explain your changes -->

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation accordingly

## Additional Notes

<!-- Add any other context about the PR here -->

> [!CAUTION]
> Do not use the green merge buttons to merge into 'release' branch. Use the `/merge` command.
