### PR TITLE
Editor no longer deletes action configuration ✂️ 🦩 

### DIFF
--- a/src/cards/editor.ts
+++ b/src/cards/editor.ts
@@ -441,7 +441,7 @@ export class PiHoleCardEditor extends LitElement {
 
     const shouldDelete = (obj: SectionConfig | undefined) =>
       obj &&
-      (Object.keys(obj).length === 0 || Object.values(obj).some((f) => !f));
+      (Object.keys(obj).length === 0 || Object.values(obj).every((f) => !f));
 
     if (shouldDelete(config.stats)) {
       delete config.stats;

--- a/test/cards/editor.spec.ts
+++ b/test/cards/editor.spec.ts
@@ -636,5 +636,62 @@ describe('editor.ts', () => {
       expect(dispatchStub.firstCall.args[0].detail.config.entity_order).to.be
         .undefined;
     });
+
+    it('should NOT remove section configs when at least one action is configured', () => {
+      const testConfig: Config = {
+        device_id: 'device_1',
+        badge: {
+          tap_action: {
+            action: 'toggle',
+          },
+        },
+        stats: {
+          tap_action: {
+            action: 'more-info',
+          },
+          hold_action: undefined,
+          double_tap_action: undefined,
+        },
+      };
+      card.setConfig(testConfig);
+
+      // Simulate value-changed event with actions configured
+      const detail = {
+        value: {
+          device_id: 'device_1',
+          badge: {
+            tap_action: {
+              action: 'toggle',
+            },
+          },
+          stats: {
+            tap_action: {
+              action: 'more-info',
+            },
+            hold_action: undefined,
+            double_tap_action: undefined,
+          },
+        },
+      };
+
+      const event = new CustomEvent('value-changed', { detail });
+      card['_valueChanged'](event);
+
+      // Verify event was dispatched with section configs preserved
+      expect(dispatchStub.calledOnce).to.be.true;
+      expect(dispatchStub.firstCall.args[0].type).to.equal('config-changed');
+      expect(dispatchStub.firstCall.args[0].detail.config.badge).to.deep.equal({
+        tap_action: {
+          action: 'toggle',
+        },
+      });
+      expect(dispatchStub.firstCall.args[0].detail.config.stats).to.deep.equal({
+        tap_action: {
+          action: 'more-info',
+        },
+        hold_action: undefined,
+        double_tap_action: undefined,
+      });
+    });
   });
 });


### PR DESCRIPTION
## Bug Fixes

- **Fixed editor deleting interaction configurations**: Fixed an issue where interaction configurations (badge, stats, info, controls) were being deleted when reopening the editor. The cleanup logic now only removes sections when all actions are empty, preserving sections that have at least one action configured.